### PR TITLE
feat: Add icons to feature and benefit cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,10 +158,25 @@
             border-radius: 8px;
             box-shadow: 0 4px 6px rgba(0,0,0,0.1);
             transition: transform 0.3s ease;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
         }
 
         .feature-card:hover {
             transform: translateY(-5px);
+        }
+
+        .feature-icon {
+            display: block; /* Ensures margin-bottom is effective */
+            margin-bottom: 1rem;
+            color: var(--primary-color); /* Or any color you prefer */
+        }
+
+        .feature-icon svg {
+            width: 48px; /* Adjust size as needed */
+            height: 48px; /* Adjust size as needed */
         }
 
         .stats-container {
@@ -266,26 +281,81 @@
             <h2 class="section-title" data-i18n="features.title" data-aos="fade-up">Comprehensive Fleet Optimization</h2>
             <div class="features-grid">
                 <div class="feature-card" data-aos="fade-up">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Smart Route Optimization Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M3 19a2 2 0 1 0 4 0a2 2 0 0 0 -4 0" />
+                            <path d="M19 7a2 2 0 1 0 0 -4a2 2 0 0 0 0 4z" />
+                            <path d="M11 19h5.5a3.5 3.5 0 0 0 0 -7h-8a3.5 3.5 0 0 1 0 -7h4.5" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="features.cards.0.title">Smart Route Optimization</h3>
                     <p data-i18n="features.cards.0.description">Optimize in-bound and out-bound deliveries with advanced algorithms considering time, cost, and legal constraints.</p>
                 </div>
                 <div class="feature-card" data-aos="fade-up" data-aos-delay="100">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Fleet Management Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M7 17m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+                            <path d="M17 17m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+                            <path d="M5 17h-2v-11a1 1 0 0 1 1 -1h9v12m-4 0h6m4 0h2v-6h-8m0 -5h5l3 5" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="features.cards.1.title">Fleet Management</h3>
                     <p data-i18n="features.cards.1.description">Optimize vehicle composition and usage patterns to maximize efficiency and minimize costs.</p>
                 </div>
                 <div class="feature-card" data-aos="fade-up" data-aos-delay="200">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Workforce Optimization Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M9 7m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" />
+                            <path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
+                            <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+                            <path d="M21 21v-2a4 4 0 0 0 -3 -3.85" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="features.cards.2.title">Workforce Optimization</h3>
                     <p data-i18n="features.cards.2.description">Manage driver schedules while ensuring compliance with legal requirements and regulations.</p>
                 </div>
                 <div class="feature-card" data-aos="fade-up" data-aos-delay="300">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Seamless Integration Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="features.cards.3.title">Seamless Integration</h3>
                     <p data-i18n="features.cards.3.description">Connect with your existing ERP, CRM, and warehouse management systems for smooth data flow.</p>
                 </div>
                 <div class="feature-card" data-aos="fade-up" data-aos-delay="400">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Custom Workflows Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M12 18m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+                            <path d="M7 6m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+                            <path d="M17 6m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+                            <path d="M7 8v2a2 2 0 0 0 2 2h6a2 2 0 0 0 2 -2v-2" />
+                            <path d="M12 12l0 4" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="features.cards.4.title">Custom Workflows</h3>
                     <p data-i18n="features.cards.4.description">Adapt our system to your existing processes instead of forcing changes to your operations.</p>
                 </div>
                 <div class="feature-card" data-aos="fade-up" data-aos-delay="500">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Mobile Access Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M6 5a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2v-14z" />
+                            <path d="M11 4h2" />
+                            <path d="M12 17v.01" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="features.cards.5.title">Mobile Access</h3>
                     <p data-i18n="features.cards.5.description">Provide drivers with easy mobile access to routes and enable real-time updates and tracking.</p>
                 </div>
@@ -296,14 +366,42 @@
             <h2 class="section-title" data-i18n="benefits.title" data-aos="fade-up">Why Choose QualiDat DRP?</h2>
             <div class="features-grid">
                 <div class="feature-card" data-aos="fade-up">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Cost Efficiency Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M15 11v.01" />
+                            <path d="M5.173 8.378a3 3 0 1 1 4.656 -1.377" />
+                            <path d="M16 4v3.803a6.019 6.019 0 0 1 2.658 3.197h1.341a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-1.342c-.336 .95 -.907 1.8 -1.658 2.473v2.027a1.5 1.5 0 0 1 -3 0v-.583a6.04 6.04 0 0 1 -1 .083h-4a6.04 6.04 0 0 1 -1 -.083v.583a1.5 1.5 0 0 1 -3 0v-2l0 -.027a6 6 0 0 1 4 -10.473h2.5l4.5 -3h0z" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="benefits.cards.0.title">Cost Efficiency</h3>
                     <p data-i18n="benefits.cards.0.description">Reduce operational costs through optimized routes and resource utilization.</p>
                 </div>
                 <div class="feature-card" data-aos="fade-up" data-aos-delay="100">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Time Savings Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+                            <path d="M12 12h3.5" />
+                            <path d="M12 7v5" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="benefits.cards.1.title">Time Savings</h3>
                     <p data-i18n="benefits.cards.1.description">Automate route planning and reduce manual intervention in daily operations.</p>
                 </div>
                 <div class="feature-card" data-aos="fade-up" data-aos-delay="200">
+                    <span class="feature-icon">
+                        <svg width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <title>Scalability Icon</title>
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M16 4l4 0l0 4" />
+                            <path d="M14 10l6 -6" />
+                            <path d="M8 20l-4 0l0 -4" />
+                            <path d="M4 20l6 -6" />
+                        </svg>
+                    </span>
                     <h3 data-i18n="benefits.cards.2.title">Scalability</h3>
                     <p data-i18n="benefits.cards.2.description">From small fleets to large operations, our solution grows with your business.</p>
                 </div>


### PR DESCRIPTION
Adds SVG icons to each card in the "Features" and "Benefits" sections of the homepage.

- Selected appropriate Tabler SVG icons to represent each item.
- Embedded SVG icons directly into `index.html`.
- Added `<title>` elements to SVGs for improved accessibility.
- Updated CSS for `.feature-card` to use flexbox, centering the icon, title, and description.
- Styled icons for size (48px), color (using `--primary-color`), and spacing.

This enhances the visual appeal and scannability of these sections.