### PR TITLE
Redesign live results score display and remove scores from details

### DIFF
--- a/waterpolo/futures/live_results.css
+++ b/waterpolo/futures/live_results.css
@@ -22,7 +22,11 @@ body {
     backdrop-filter: blur(15px);
     border-radius: 20px;
     box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
-    overflow: hidden;
+    /* overflow: hidden; */ /* Replaced by flexbox structure */
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 16px); /* Adjust based on body padding, or use 100% if body has fixed height */
+    max-height: calc(100vh - 16px); /* Ensure it doesn't exceed viewport with padding */
 }
 
 .header {
@@ -31,6 +35,7 @@ body {
     padding: 15px 12px;
     text-align: center;
     position: relative;
+    flex-shrink: 0; /* Prevent header from shrinking */
 }
 
 .title {
@@ -80,6 +85,7 @@ body {
     align-items: center;
     flex-wrap: wrap;
     gap: 8px;
+    flex-shrink: 0; /* Prevent status-bar from shrinking */
 }
 
 .status-info {
@@ -126,8 +132,10 @@ body {
 
 .data-container {
     padding: 12px;
-    max-height: 80vh;
+    /* max-height: 80vh; */ /* Removed, flex-grow will manage height */
     overflow-y: auto;
+    flex-grow: 1; /* Allow this container to take up available space */
+    min-height: 0; /* Important for flex children to shrink properly */
 }
 
 .match-grid {
@@ -146,9 +154,14 @@ body {
     transition: all 0.3s ease;
     animation: slideInUp 0.6s ease-out;
     position: relative;
-    overflow: hidden;
-    min-height: 120px;
-    max-height: 140px;
+    /* overflow: hidden; */ /* Allow content to define height, remove fixed heights */
+    /* min-height: 120px; */ /* Removed */
+    /* max-height: 140px; */ /* Removed */
+    overflow-wrap: break-word; /* Ensure long text wraps */
+    word-wrap: break-word; /* Legacy support for word-wrap */
+    display: flex; /* Use flexbox for better internal alignment */
+    flex-direction: column; /* Stack children vertically */
+    justify-content: space-between; /* Distribute space if card grows */
 }
 
 .match-card::before {
@@ -243,15 +256,97 @@ body {
 .match-teams {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: center; /* Vertically align items within match-teams */
     margin-bottom: 8px;
-    gap: 6px;
+    gap: 6px; /* Gap between team sections and center score */
 }
 
 .team-info {
-    flex: 1;
-    min-width: 80px;
+    flex: 1; /* Allow team info sections to take up space */
+    /* min-width: 80px; */ /* Replaced by flex basis or explicit width for children */
+    display: flex;
+    flex-direction: column; /* Stack team name and score vertically */
 }
+
+.team-info.team-left {
+    align-items: flex-start; /* Align text to the left */
+}
+
+.team-info.team-right {
+    align-items: flex-end; /* Align text to the right */
+}
+
+.team-score-value {
+    font-size: clamp(1.0rem, 4vw, 1.2rem); /* Slightly smaller than center score */
+    font-weight: 600;
+    color: #34495e; /* Darker grey for individual scores */
+    line-height: 1;
+    margin-top: 2px;
+}
+
+.match-card.shores-highlight .team-score-value {
+    color: #e85a19; /* Shores highlight for individual scores */
+}
+
+.score-center {
+    flex-grow: 0;
+    flex-shrink: 0;
+    padding: 0 10px; /* Space around the central score/vs text */
+    text-align: center;
+}
+
+.center-score-display {
+    font-size: clamp(1.3rem, 5vw, 1.8rem); /* Prominent central score */
+    font-weight: 800;
+    color: #0077be;
+    background-color: rgba(0, 119, 190, 0.05);
+    padding: 4px 8px;
+    border-radius: 6px;
+    line-height: 1;
+    display: inline-block;
+}
+
+.match-card.shores-highlight .center-score-display {
+    color: #ff6b35;
+    background-color: rgba(255, 107, 53, 0.05);
+}
+
+.vs-text-center {
+    font-size: clamp(1.0rem, 4vw, 1.2rem);
+    font-weight: 700;
+    color: #6c757d;
+    line-height: 1;
+}
+
+@media (max-width: 360px) {
+    .match-teams {
+        gap: 4px; /* Reduce gap on very small screens */
+        /* Potentially change to flex-direction: column if horizontal is too cramped */
+        /* align-items: stretch; */ /* if changing to column, might want this */
+    }
+
+    .score-center {
+        padding: 0 5px; /* Reduce padding for center score */
+    }
+
+    .team-name {
+        font-size: clamp(0.75rem, 3.5vw, 0.9rem); /* Slightly smaller base for very narrow */
+    }
+
+    .center-score-display {
+        font-size: clamp(1.1rem, 5vw, 1.6rem); /* Adjust central score font */
+        padding: 3px 6px;
+    }
+
+    .team-score-value {
+        font-size: clamp(0.9rem, 4vw, 1.1rem);
+    }
+
+    .vs-text-center {
+        font-size: clamp(0.9rem, 4vw, 1.1rem);
+    }
+}
+
 
 .team-name {
     font-weight: 700;
@@ -259,9 +354,10 @@ body {
     color: #2c3e50;
     margin-bottom: 2px;
     line-height: 1.1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    /* overflow: hidden; */ /* Allow wrapping */
+    /* text-overflow: ellipsis; */ /* Ellipsis is less useful with wrapping */
+    /* white-space: nowrap; */ /* Allow wrapping */
+    word-break: break-word; /* Ensure long words break and wrap */
 }
 
 .team-name.shores-team {
@@ -269,24 +365,24 @@ body {
     text-shadow: 0 1px 3px rgba(255, 107, 53, 0.2);
 }
 
-.team-score {
-    font-size: clamp(1.2rem, 5vw, 1.6rem);
-    font-weight: 800;
-    color: #0077be;
-    line-height: 1;
-}
+/* .team-score { */ /* Old style, replaced by .team-score-value and .center-score-display */
+    /* font-size: clamp(1.2rem, 5vw, 1.6rem); */
+    /* font-weight: 800; */
+    /* color: #0077be; */
+    /* line-height: 1; */
+/* } */
 
-.match-card.shores-highlight .team-score {
-    color: #ff6b35;
-}
+/* .match-card.shores-highlight .team-score { */ /* Old style */
+    /* color: #ff6b35; */
+/* } */
 
-.vs-divider {
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: #6c757d;
-    margin: 0 6px;
-    white-space: nowrap;
-}
+/* .vs-divider { */ /* Old style, replaced by .score-center and .vs-text-center */
+    /* font-size: 0.8rem; */
+    /* font-weight: 600; */
+    /* color: #6c757d; */
+    /* margin: 0 6px; */
+    /* white-space: nowrap; */
+/* } */
 
 .match-actions {
     display: flex;
@@ -500,6 +596,7 @@ body {
     color: #6c757d;
     font-size: 0.75rem;
     line-height: 1.3;
+    flex-shrink: 0; /* Prevent footer from shrinking */
 }
 
 .stats-grid {
@@ -590,6 +687,11 @@ body {
     body {
         padding: 15px;
     }
+
+    .container {
+        height: calc(100vh - 30px); /* 15px top + 15px bottom body padding */
+        max-height: calc(100vh - 30px);
+    }
     
     .match-grid {
         grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
@@ -597,8 +699,8 @@ body {
     }
     
     .match-card {
-        min-height: 140px;
-        max-height: 160px;
+        /* min-height: 140px; */ /* Removed */
+        /* max-height: 160px; */ /* Removed */
         padding: 16px;
     }
     

--- a/waterpolo/futures/live_results.html
+++ b/waterpolo/futures/live_results.html
@@ -9,7 +9,7 @@
 <body>
     <!-- Floating Back Button -->
     <a href="../index.html" class="floating-back-btn" id="floatingBackBtn">
-        <img src="https://sdshores.org/sites/all/themes/jango/jango_sub/logo.png" alt="SD Shores Logo" />
+        <img src="sd_shores_logo.png" alt="Back to Home" />
     </a>
     
     <div class="container">

--- a/waterpolo/futures/live_results.js
+++ b/waterpolo/futures/live_results.js
@@ -134,14 +134,21 @@ function createMatchCard(line, cardNumber, isShoresMatch) {
         </div>
         
         <div class="match-teams">
-            <div class="team-info">
+            <div class="team-info team-left">
                 <div class="team-name ${matchData.team1.isShores ? 'shores-team' : ''}">${matchData.team1.name}</div>
-                ${matchData.team1.score !== null ? `<div class="team-score">${matchData.team1.score}</div>` : ''}
+                ${matchData.team1.score !== null ? `<div class="team-score-value">${matchData.team1.score}</div>` : '<div class="team-score-value">-</div>'}
             </div>
-            <div class="vs-divider">VS</div>
-            <div class="team-info" style="text-align: right;">
+            <div class="score-center">
+                ${matchData.team1.score !== null && matchData.team2.score !== null ?
+                    `<span class="center-score-display">${matchData.team1.score} - ${matchData.team2.score}</span>` :
+                    (matchData.team1.score !== null || matchData.team2.score !== null ?
+                        `<span class="center-score-display">${matchData.team1.score !== null ? matchData.team1.score : '-'} - ${matchData.team2.score !== null ? matchData.team2.score : '-'}</span>` :
+                        `<span class="vs-text-center">VS</span>`)
+                }
+            </div>
+            <div class="team-info team-right">
                 <div class="team-name ${matchData.team2.isShores ? 'shores-team' : ''}">${matchData.team2.name}</div>
-                ${matchData.team2.score !== null ? `<div class="team-score">${matchData.team2.score}</div>` : ''}
+                ${matchData.team2.score !== null ? `<div class="team-score-value">${matchData.team2.score}</div>` : '<div class="team-score-value">-</div>'}
             </div>
         </div>
         
@@ -158,10 +165,7 @@ function createMatchCard(line, cardNumber, isShoresMatch) {
                 </div>
                 
                 <div class="score-separator">
-                    ${matchData.team1.score !== null && matchData.team2.score !== null ? 
-                        `<span class="score-display">${matchData.team1.score} - ${matchData.team2.score}</span>` : 
-                        `<span class="vs-text">VS</span>`
-                    }
+                    <span class="vs-text">VS</span>
                 </div>
                 
                 <div class="team-detail right">


### PR DESCRIPTION
- Modified the main score display in match cards to a three-column layout: Team1+Score (left), Combined Score (center), Team2+Score (right).
- Removed match scores from the expandable 'Details' section to avoid redundancy.
- Updated CSS to style the new score layout, ensuring it's responsive across various screen sizes.
- Added a media query for screens <= 360px to fine-tune fonts and spacing for very narrow displays.